### PR TITLE
Removed format check for locator exit code

### DIFF
--- a/cpp/src/LocationResult.cpp
+++ b/cpp/src/LocationResult.cpp
@@ -39,7 +39,7 @@ LocationResult::LocationResult() {
 	minimumDistance = std::numeric_limits<double>::quiet_NaN();
 	rms = std::numeric_limits<double>::quiet_NaN();
 	quality = "";
-  bayesianDepth = std::numeric_limits<double>::quiet_NaN();
+  	bayesianDepth = std::numeric_limits<double>::quiet_NaN();
 	bayesianRange = std::numeric_limits<double>::quiet_NaN();
 	depthImportance = std::numeric_limits<double>::quiet_NaN();
 	locatorExitCode = "";

--- a/format-docs/LocationResult.md
+++ b/format-docs/LocationResult.md
@@ -140,7 +140,6 @@ kilometers
 kilometers
 * DepthImportance - A number containing the importance from the bayesian
 depth constraint
-* LocatorExitCode - A String containing the locator exit code, allowed values
-are: "Success", "DidNotMove", "ErrorsNotComputed", "Failed", and "Unknown"
+* LocatorExitCode - A String containing the locator exit code.
 * ErrorEllipse - An object containing the error ellipse of the Location, see
 [ErrorEllipse](ErrorEllipse.md)

--- a/java/src/main/java/gov/usgs/processingformats/LocationResult.java
+++ b/java/src/main/java/gov/usgs/processingformats/LocationResult.java
@@ -821,29 +821,8 @@ public class LocationResult implements ProcessingInt {
       }
     }
 
-    // locator exit code
-    if (LocatorExitCode != null) {
-      boolean match = false;
-      if (LocatorExitCode.equals("Success")) {
-        match = true;
-      } else if (LocatorExitCode.equals("DidNotMove")) {
-        match = true;
-      } else if (LocatorExitCode.equals("ErrorsNotComputed")) {
-        match = true;
-      } else if (LocatorExitCode.equals("Failed")) {
-        match = true;
-      } else if (LocatorExitCode.equals("Unknown")) {
-        match = true;
-      } else {
-        match = false;
-      }
-
-      if (!match) {
-        // invalid eventType
-        errorList.add("Invalid locator exit code in LocationResult Class.");
-      }
-    }
-
+    // locator exit code has no validation
+    
     // error ellipse
     if (ErrorEllipse != null) {
       if (!ErrorEllipse.isValid()) {

--- a/python/processingformats/locationResult.py
+++ b/python/processingformats/locationResult.py
@@ -350,33 +350,7 @@ class LocationResult:
             if self.secondaryGap < 0 or self.secondaryGap > 360:
                 errorList.append('Secondary gap in LocationResult Class not in the range of 0 to 360.')
         
-        # Locator Exit Code
-        try:
-            match = False
-            
-            if self.locatorExitCode == "Success":
-                match = True
-                
-            elif self.locatorExitCode == "DidNotMove":
-                match = True
-                
-            elif self.locatorExitCode == "ErrorsNotComputed":
-                match = True
-                
-            elif self.locatorExitCode == "Failed":
-                match = True
-                
-            elif self.locatorExitCode == "Unknown":
-                match = True
-                
-            else:
-                match = False
-                
-            if not match:
-                errorList.append("Invalid locator exit code in LocationResult Class")
-        except(NameError, AttributeError):
-            errorList.append('No locator exit code in LocationResult Class.')
-                
+        # Locator Exit Code has no validation                
         
         # Error Ellipse
         if hasattr(self, 'errorEllipse'):


### PR DESCRIPTION
This PR removes the format checks for the locator exit code key in location result, making it a free text field. This is due to the variability of locator return codes, and for future flexibility. 